### PR TITLE
Changed calls to scale(x, A) to Diagonal(x)*A

### DIFF
--- a/src/wls.jl
+++ b/src/wls.jl
@@ -36,9 +36,9 @@ function wls(y::Array{Float64,2},X::Array{Float64,2},w::Array{Float64,1},
     sqrtw = sqrt(w)
     # scale by weights
     # yy = y.*sqrtw
-    yy = scale(sqrtw,y)
+    yy = Diagonal(sqrtw)*y
     # XX = diagm(sqrtw)*X
-    XX = scale(sqrtw,X)
+    XX = Diagonal(sqrtw)*X
         
     # QR decomposition of the transformed data
     (q,r) = qr(XX)


### PR DESCRIPTION
In Julia v0.5, there are warnings that "scale(x::AbstractVector,A::AbstractMatrix) is deprecated, use Diagonal(x) * A" for two lines in the wls.jl code. I have changed these two lines to the Diagonal(x) * A format. This still doesn't explain the negative weights error. 

Additionally, in v0.5, I get four "Base.ASCIIString is deprecated, use String instead" warnings for line 44 in lmmtest.jl (this is where you start looping through phenotypes). It's unclear to me what the true source of this error is, but it seems unlikely to cause big problems. 

ETA: Build failing due to negative weights error. Looks like maybe the optimized h2 was negative? Not sure if this is possible. 